### PR TITLE
Fix typo in Gemini tutorial mission

### DIFF
--- a/Gemini/tutorialAscent.json
+++ b/Gemini/tutorialAscent.json
@@ -794,7 +794,7 @@
       "Timestamp": 0.0,
       "DisplayTime": 3.0,
       "From": 2,
-      "Message": "When the launch vehicle inserts you into orbit, there will be a difference between the planned orbit and your actial orbit. The IVIs will try to indicate the difference, and you can use the OAMS to try and null them.",
+      "Message": "When the launch vehicle inserts you into orbit, there will be a difference between the planned orbit and your actual orbit. The IVIs will try to indicate the difference, and you can use the OAMS to try and null them.",
       "Value1": 0.0,
       "Value2": 0.0,
       "Value3": 0.0,


### PR DESCRIPTION
`actial` -> `actual`